### PR TITLE
hide overflow in as seen on

### DIFF
--- a/src/scss/App.scss
+++ b/src/scss/App.scss
@@ -221,6 +221,7 @@ $phi: 1.6180339887498948482;
   background: darken($darkest, 4%);
   padding: 30px 0;
   padding-bottom: 50px;
+  overflow:hidden;
 
   h3 {
     font-family: 'Montserrat', sans-serif;


### PR DESCRIPTION
Hide overflow in as seen on so that it doesn't make the page scroll horizontally on small screens/windows.