### PR TITLE
Add 100% width to img to eliminate overflow

### DIFF
--- a/src/HowItWorks.js
+++ b/src/HowItWorks.js
@@ -15,7 +15,7 @@ const HowItWorks = () => (
         </div>
 
         <div className='network-grid'>
-          <img src={elephantGrid} alt='Fediverse' />
+          <img src={elephantGrid} alt='Fediverse' width='100%' />
         </div>
       </div>
 


### PR DESCRIPTION
This should just make it fit better on small screens. Currently it overflows horizontally.