### PR TITLE
Use new instances.social API

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -42,7 +42,7 @@ export default class Wizard extends React.PureComponent {
 
         <div className='wizard-controls'>
           <div classname='external-wizard'>
-            <a className='cta button' target='_blank' href="https://instances.mastodon.xyz">
+            <a className='cta button' target='_blank' href="https://instances.social">
               Help me choose
             </a>
           </div>

--- a/src/WizardRow.js
+++ b/src/WizardRow.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const WizardRow = ({ instance }) => {
-  const theme = (instance.info && instance.info.theme) || 'General';
+  const theme = (instance.info && instance.info.topic) || 'General';
 
   let stabilityColor, stabilityLabel,
       populationColor, populationLabel;

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+const INSTANCES_API_TOKEN = 'JEzPe4Ff5c5WA7k4IP5tx0rJMDzEMFxhmXXZvBG4LFSF0Almf0ewfBAKtbPsqMWx1E0hYe6Wy2Zx6HJHP2LmSwUvKneZVOOnelmFaGB7yNeoCvWUxfM0WyVL0FODQPm7';
+
 export const INSTANCES_FETCH_SUCCESS = 'INSTANCES_FETCH_SUCCESS';
 export const SEARCH_VALUE_CHANGE     = 'SEARCH_VALUE_CHANGE';
 
@@ -9,8 +11,9 @@ export function fetchInstances() {
       return;
     }
 
-    axios.get('https://instances.social/instances.json')
-      .then(response => dispatch(fetchInstancesSuccess(response.data)));
+    axios('https://instances.social/api/1.0/instances/list?count=0', {
+        headers: {'Authorization': `Bearer ${INSTANCES_API_TOKEN}`},
+    }).then(response => dispatch(fetchInstancesSuccess(response.data.instances)));
   };
 };
 


### PR DESCRIPTION
Replaces old /instances.json by new /api/1.0/instances/list

I think it would be better using /instances/sample to get some random instances to populate the table when loading the page. It would prevent loading 1300+ instances each time which causes a small freeze in the navigator.
https://instances.social/api/doc/#api-Instances-GetInstancesSample

Then /instances/search could be used to search instances when typing in the search box.
https://instances.social/api/doc/#api-Instances-SearchInstances

I never do things with React & co so I don't think I'm able to do that right now.