### PR TITLE
Randomize the list of instances

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -12,7 +12,7 @@ export function fetchInstances() {
       return;
     }
 
-    axios('https://instances.social/api/1.0/instances/list?count=0', {
+    axios('https://instances.social/api/1.0/instances/sample?count=100', {
         headers: {'Authorization': `Bearer ${INSTANCES_API_TOKEN}`},
     }).then(response => dispatch(fetchInstancesSuccess(response.data.instances)));
   };


### PR DESCRIPTION
The list of instances is now some non-semantic order (physical position in the database?). It has better to be randomized.