### PR TITLE
Remove othering: user → people

### DIFF
--- a/src/Features.js
+++ b/src/Features.js
@@ -22,7 +22,7 @@ const Features = () => (
     <div className='feature container'>
       <div className='right visual'><i className='ion-ios-people' /></div>
       <div className='left text'>
-        <h2><FormattedMessage id='features.user_first' defaultMessage='Putting the user first' /></h2>
+        <h2><FormattedMessage id='features.user_first' defaultMessage='Putting people first' /></h2>
         <p><FormattedMessage id='features.user_first_text' defaultMessage='You’re a person, not a product. Mastodon is a free, open-source development that has been crowdfunded, not financed. All instances are <strong>independently owned, operated, and moderated</strong>. There is no monopoly by a single commercial company, no ads, and no tracking. <strong>Mastodon works for you</strong>, and not the other way around.' /></p>
       </div>
     </div>


### PR DESCRIPTION
Let’s try not to refer to people as people whenever possible. It removes the othering (“users” creates a different group to us as “developers” and “designers”). Sometimes it might be impossible to avoid using the term (although you’d be surprised how often you can replace “user“ with “person” and not lose any meaning). Also, as developers and designers, we are also the users of Mastodon so “user” is really more a role than an identity. When we’re talking about people, let’s try to call them people whenever possible and perhaps only use “user“ when referring to a person playing that role at a specific time (when we need to expressly differentiate the role from other roles).

(Also, as evidenced in this case, the title reads better and sounds more human.) :)