### PR TITLE
Additional Features list : better legibility

### DIFF
--- a/src/scss/App.scss
+++ b/src/scss/App.scss
@@ -382,6 +382,11 @@ $phi: 1.6180339887498948482;
 
     li {
       display: flex;
+      line-height: 1.5em;
+      padding-bottom: .5em;
+      -webkit-column-break-inside: avoid; /* Chrome, Safari, Opera */
+          page-break-inside: avoid; /* Firefox */
+               break-inside: avoid; /* IE 10+ */
 
       i {
         display: block;


### PR DESCRIPTION
I'm proposing a better presentation for the Additional Features list.
Before: https://boitam.eu/system/media_attachments/files/000/026/510/original/c7d56826b6cc8f92.png
After: https://boitam.eu/system/media_attachments/files/000/026/511/original/ae3eff10ff2c4c68.png

First, I reduce line-height on individual li but add bottom padding, so that multi-line sentences are grouped
I also specify that LI elements shouldn't break from one column to another in Chrome. The break-* property is not well supported in Firefox, but Firefox doesn't break LI elements.