### PR TITLE
wizard: add a one-line "how it works/don't panic" above

### DIFF
--- a/src/Wizard.js
+++ b/src/Wizard.js
@@ -72,6 +72,8 @@ class Wizard extends React.PureComponent {
       <div className='wizard-page' id='getting-started'>
         <h1><i className='ion-person-add' /> <FormattedMessage id='wizard.sign_up' defaultMessage='Sign up' /></h1>
 
+        <p><FormattedMessage id='wizard.dontpanic' defaultMessage='The Mastodon world, the fediverse, consists of many interconnected instances. No matter which instance you sign up from, you will be able to follow people from any server in the fediverse.' /></p>
+
         <form className='wizard-controls'>
           <div className='row'>
             <ReactResponsiveSelect


### PR DESCRIPTION
The current "getting started" part simply takes you to the sign up without any explanation. People tend to panick when confronted with a form with no instruction provided. This commit adds such a quick explanation.

The current hint is insufficient because it not only comes after the form, but also does not directly explain what the list is supposed to do.

This fix #96.