### PR TITLE
Fix WhaleBird's URL

### DIFF
--- a/src/BrowseApps.js
+++ b/src/BrowseApps.js
@@ -118,7 +118,7 @@ const apps = {
     {
       name: 'Whalebird',
       icon: whalebird,
-      url: 'https://whalebird.org',
+      url: 'https://whalebird.social',
     },
 
     {


### PR DESCRIPTION
* The old site whalebird.org is no longer accessible. The app
  is now on whalebird.social instead.