### PR TITLE
fix: Improve description text overflow handling in ServerCard

### DIFF
--- a/components/ServerCard.tsx
+++ b/components/ServerCard.tsx
@@ -61,7 +61,7 @@ const ServerCard = ({ server }: { server?: Server }) => {
         <p className="b1 !font-700 mb-2">
           {server ? server.domain : <SkeletonText className="w-[14ch]" />}
         </p>
-        <p className="b3 line-clamp-5 [unicode-bidi:plaintext] break-words">
+        <p className="b3 line-clamp-5 [unicode-bidi:plaintext] break-words break-all overflow-hidden">
           {server ? (
             server.description
           ) : (


### PR DESCRIPTION
Added 'break-all' and 'overflow-hidden' classes to the server description paragraph to better handle long or overflowing text.

Before:
<img width="1193" height="426" alt="image" src="https://github.com/user-attachments/assets/ef1eb388-584d-46df-953b-cb50e6f24231" />

After:
<img width="1018" height="448" alt="image" src="https://github.com/user-attachments/assets/e8a5e086-0efc-4dc5-afbf-f8c23150311e" />
