### PR TITLE
Link server domains in cards

### DIFF
--- a/components/LinkButton.tsx
+++ b/components/LinkButton.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link"
+import Link, { LinkProps } from "next/link"
 import classnames from "classnames"
 
 type LinkButtonProps = {
@@ -14,6 +14,8 @@ type LinkButtonProps = {
   light?: boolean
   /** Buttons size, using `b3` typically, or `b1` on `large` */
   size: "small" | "medium" | "large"
+  /** Whether to allow a referrer to be passed */
+  allowReferrer?: boolean
 }
 
 /**
@@ -26,16 +28,14 @@ const LinkButton = ({
   href,
   light,
   size,
+  allowReferrer = false,
 }: LinkButtonProps) => {
-  let linkAttrs: {
-    target?: string
-    rel?: string
-  } = {}
+  let linkAttrs: React.JSX.IntrinsicElements["a"] = {}
 
   // check if absolute url
   if (href.indexOf("http://") === 0 || href.indexOf("https://") === 0) {
     linkAttrs.target = "_blank"
-    linkAttrs.rel = "noopener noreferrer"
+    linkAttrs.rel = allowReferrer ? "noopener" : "noopener noreferrer"
   }
 
   return (

--- a/components/ServerCard.tsx
+++ b/components/ServerCard.tsx
@@ -5,7 +5,6 @@ import { Blurhash } from "react-blurhash"
 import LinkButton from "./LinkButton"
 import type { Server } from "../types/api"
 import { categoriesMessages } from "../data/categories"
-import { formatNumber } from "../utils/numbers"
 import SkeletonText from "./SkeletonText"
 
 /**
@@ -59,7 +58,18 @@ const ServerCard = ({ server }: { server?: Server }) => {
           )}
         </p>
         <p className="b1 !font-700 mb-2">
-          {server ? server.domain : <SkeletonText className="w-[14ch]" />}
+          {server ? (
+            <a
+              href={`https://${server.domain}`}
+              target="_blank"
+              rel="noopener" // Deliberately including referrer so servers can see where people are coming from.
+              className="hover:underline"
+            >
+              {server.domain}
+            </a>
+          ) : (
+            <SkeletonText className="w-[14ch]" />
+          )}
         </p>
         <p className="b3 line-clamp-5 [unicode-bidi:plaintext] break-words break-all overflow-hidden">
           {server ? (
@@ -81,6 +91,7 @@ const ServerCard = ({ server }: { server?: Server }) => {
             light={server.approval_required}
             fullWidth
             size="small"
+            allowReferrer
           >
             {server.approval_required ? (
               <FormattedMessage


### PR DESCRIPTION
Fixes #1009.

This links server domains in cards for people that want to check out the server and not just sign up. This also sends referrer headers to servers so they see joinmastodon.org as a traffic source.