### PR TITLE
Add recent dotSocial episode to media interviews list.

### DIFF
--- a/data/interviews.ts
+++ b/data/interviews.ts
@@ -1,6 +1,6 @@
 const interviews = [
   {
-    url: "https://dot-social.simplecast.com/episodes/felix-hlatky/transcript",
+    url: "https://dot-social.simplecast.com/episodes/felix-hlatky/",
     title:
       "Mastodon’s First and Next 10 Years, with Executive Director Felix Hlatky",
     show: "dotSocial",

--- a/data/interviews.ts
+++ b/data/interviews.ts
@@ -1,5 +1,13 @@
 const interviews = [
   {
+    url: "https://dot-social.simplecast.com/episodes/felix-hlatky/transcript",
+    title:
+      "Mastodon’s First and Next 10 Years, with Executive Director Felix Hlatky",
+    show: "dotSocial",
+    date: "2026-05-27",
+    icon: require("../public/press/dotsocial.jpg"),
+  },
+  {
     url: "https://www.europeanspodcast.com/all-episodes/europes-anti-elon",
     title:
       "Europe's anti-Elon",


### PR DESCRIPTION
I'm guessing the comms folks may want to keep on top of adding these interviews, in case I missed this task in my handover document.